### PR TITLE
Standardize Port Usage: Replace Port 3000 with 8888

### DIFF
--- a/example_tool/src/main.cpp
+++ b/example_tool/src/main.cpp
@@ -17,13 +17,13 @@ void usage()
 	cout<<"mddriverconstraint"<<endl;
 	cout<<"\tOptions : "<<endl;
 	cout<<"\t\t[-host hostname] : default = localhost"<<endl;
-	cout<<"\t\t[-port port] : default = 3000"<<endl;
+	cout<<"\t\t[-port port] : default = 8888"<<endl;
 	exit(1);
 	}
 
 int main( int argc, char *argv[] )
 	{
-	unsigned port=3000;
+	unsigned port=8888;
 	char hostname[HOSTMAXSIZE]="localhost";
 	unsigned minimaloptionok=false;
 

--- a/protocol/python/mddriver0.1/mddriver/mddriver.c
+++ b/protocol/python/mddriver0.1/mddriver/mddriver.c
@@ -30,7 +30,7 @@ static PyObject * mddriver_client(PyObject *self, PyObject *args)
 	char * filename;
 	int mode=0;
 	int wait=0;
-	int port=3000;
+	int port=8888;
 	int message=0;
 	char * hostname;
 	if (!PyArg_ParseTuple(args, "siis:mddriver_client", &hostname, &port, &message, &filename))
@@ -47,7 +47,7 @@ static PyObject * mddriver_server(PyObject *self, PyObject *args)
 	char * filename;
 	int mode=1;
 	int wait=0;
-	int port=3000;
+	int port=8888;
 	int message=0;
 	if (!PyArg_ParseTuple(args, "iiis:mddriver_server",&port,&wait,&message,&filename))
 		{

--- a/protocol/python/mddriverclient.py
+++ b/protocol/python/mddriverclient.py
@@ -2,7 +2,7 @@ from mddriver import *
 from time import *
 
 clienthostname="127.0.0.1"
-port=3000
+port=8888
 message=2
 wait=0
 filenameclient="client.log"

--- a/protocol/python/mddriverserver.py
+++ b/protocol/python/mddriverserver.py
@@ -2,7 +2,7 @@
 from time import *
 from mddriver import *
 
-port=3000
+port=8888
 message=2
 wait=1
 filenameserver="server.log"

--- a/protocol/src/imd_interface.c
+++ b/protocol/src/imd_interface.c
@@ -102,7 +102,7 @@ static int IMDwait = 0;
 static imd_int32 IMDignore = 0;
 
 // Connection port number
-static imd_int32 IMDport = 3000 ;
+static imd_int32 IMDport = 8888 ;
 
 // Message level
 //   0 -> Only error messages
@@ -837,7 +837,7 @@ FILE *IIMD_init( const char  *hostname,     imd_int32   *mode,  imd_int32   *IMD
 		if ( IMDport  <= 1024 )
 		{
 			fprintf(IMDlog, "MDDriver >      Bad port number (using %d) \n", IMDport);
-			IMDport = 3000;
+			IMDport = 8888;
 		}
 
 		int newport = find_free_port(sock, hostname, IMDport);

--- a/protocol/test_exe/clienttest.c
+++ b/protocol/test_exe/clienttest.c
@@ -91,7 +91,7 @@ typedef float t_coord[3];
 
 FILE *IMDlog;
 char IMDhostname[] = "localhost";
-int IMDport   = 3000;
+int IMDport   = 8888;
 int IMDmsg = 2;
 int IMDwait   = 0;                     // Connection configuration
 int IMDmode = 0; // 0 : client , 1 : server

--- a/protocol/test_exe/protocoltest.c
+++ b/protocol/test_exe/protocoltest.c
@@ -92,7 +92,7 @@ static       IMDGrid grid; // Communication buffer for energies
 
 int nstximd              = 0;
 int myimd_wait           = 1;
-int myimd_port           = -3000; // If the value is negative, we will print debug output!
+int myimd_port           = -8888; // If the value is negative, we will print debug output!
 
 void myimd_init( )
 {	// --- MDD Initialization function ---

--- a/protocol/test_exe/servertest.c
+++ b/protocol/test_exe/servertest.c
@@ -226,7 +226,7 @@ int myimd_wait           = 1;
 int myimd_log           = 2;
 
 // If the value is negative, we will print debug output!
-int myimd_port           = 3000;
+int myimd_port           = 8888;
 
 
 // MDD Initialization function


### PR DESCRIPTION
This PR updates all occurrences of port 3000 to port 8888 to align with the default port used by UnityMol and GROMACS for IMD (Interactive Molecular Dynamics) communication.

Dependency:
⚠️ This PR depends on another PR Hotfix/build workflow fix: https://github.com/LBT-CNRS/MDDriver/pull/8
Please ensure that the linked PR is merged (and tested) before merging this one to avoid breaking compatibility.