### PR TITLE
Hotfix/build workflow fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Archive UnityMol Plugin library
         uses: actions/upload-artifact@v4
         with:
-          name: UnityMol-Plugin
+          name: UnityMol-Plugin-${{ matrix.os }}
           path: |
             build/plugins/libUnity_MDDriver.*
             build/plugins/Debug/Unity_MDDriver.dll

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure
         run: cmake -S . -B build
@@ -23,7 +23,7 @@ jobs:
         run: cmake --build build
 
       - name: Archive UnityMol Plugin library
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: UnityMol-Plugin
           path: |


### PR DESCRIPTION
- 1ccbe5333f0014ed81ff51a252f068be2fe20de3 → Fix the error: `Error: Missing download info for actions/upload-artifact@v3` : [https://github.com/LBT-CNRS/MDDriver/actions/runs/13836240048/job/38711862238](https://github.com/LBT-CNRS/MDDriver/actions/runs/13836240048/job/38711862238)

- b4584d7d47e04ada9e40a32afd38b5c8d18a7f3f → Fix the error : `Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run` ([https://github.com/LBT-CNRS/MDDriver/actions/runs/13837255258/job/38715340008](https://github.com/LBT-CNRS/MDDriver/actions/runs/13837255258/job/38715340008)